### PR TITLE
Extract request and parsing portions of Get()

### DIFF
--- a/v2/forecast.go
+++ b/v2/forecast.go
@@ -75,6 +75,7 @@ type Forecast struct {
 	Alerts    []alert   `json:"alerts"`
 	Flags     Flags     `json:"flags"`
 	APICalls  int       `json:"apicalls"`
+	Code      int       `json:"code"`
 }
 
 type Units string


### PR DESCRIPTION
@bcobb and I needed to do this to cache the returned JSON, as well as injecting fake JSON for testing. The function signature and behavior of `Get()` should not have changed.