### PR TITLE
Added fields to 'alert'

### DIFF
--- a/v2/forecast.go
+++ b/v2/forecast.go
@@ -61,6 +61,8 @@ type DataBlock struct {
 
 type alert struct {
 	Title       string  `json:"title"`
+	Description string  `json:"description"`
+	Time        float64 `json:"time"`
 	Expires     float64 `json:"expires"`
 	URI         string  `json:"uri"`
 }

--- a/v2/forecast.go
+++ b/v2/forecast.go
@@ -60,9 +60,9 @@ type DataBlock struct {
 }
 
 type alert struct {
-	Title   string  `json:"title"`
-	Expires float64 `json:"expires"`
-	URI     string  `json:"uri"`
+	Title       string  `json:"title"`
+	Expires     float64 `json:"expires"`
+	URI         string  `json:"uri"`
 }
 
 type Forecast struct {


### PR DESCRIPTION
The 'description' and 'time' fields were missing from the 'alert' type